### PR TITLE
Add Code Diff Reviewer task model

### DIFF
--- a/configs/chat_completions/testing/code_diff_reviewer.json
+++ b/configs/chat_completions/testing/code_diff_reviewer.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://raw.githubusercontent.com/imranq2/language_model_gateway/main/language_model_gateway/configs/config_schema.json",
+  "id": "code_diff_reviewer",
+  "name": "Code Diff Reviewer",
+  "description": "Takes a code diff (output of git diff) as an input and returns a few suggestions on how to improve the code.",
+  "owner": "Kevin LeStarge",
+  "system_prompts": [
+    {
+      "role": "system",
+      "content": "You are a human code reviewer who only has access to the diff of the code changes. Your primary goal is to protect the codebase from any changes that may cause bugs. You also want to help the developer whose code you are reviewing understand why you are making certain suggestions. Unfortunately, you don't have the full context of the code repository in which you are reviewing. You only have visibility into the diff of the lines that have changed. So make sure to only comment on things you are confident should be changed even without the context of the rest of the repo. When in doubt about the value of your feedback due to not enough context, error on the side of not saying anything."
+    }
+  ],
+  "model_parameters": [
+    {
+      "key": "temperature",
+      "value": 0
+    }
+  ],
+  "headers": [
+    {
+      "key": "Authorization",
+      "value": "Bearer OPENAI_API_KEY"
+    }
+  ],
+  "tools": [
+    {
+      "name": "current_date",
+      "parameters": [
+        {
+          "key": "format",
+          "value": "YYYY-MM-DD"
+        }
+      ]
+    },
+    {
+      "name": "web_search"
+    },
+    {
+      "name": "get_web_page"
+    }
+  ],
+  "example_prompts": [
+    {
+      "role": "user",
+      "content": "Review this PR diff and give a short one sentence summary of the changes followed by your top 1 to 5 code change suggestions for improvement. Please give a specific example of your code change suggestion, and label each suggestion as one of the following (depending on how important you regard your suggestion to be): 'Critical', 'Recommended', or 'Optional'. Critical would be a blocker for the PR that definitely needs to be addressed, so only label something as critical if you're sure it needs to change. Recommended would be for best practices, but the code changes would probably still work fine as-is. Optional would be for NIT comments that don't really matter very much."
+    }
+  ]
+}


### PR DESCRIPTION
The plan is to have a better task model to plug [our AI PR reviewer tooling](https://github.com/icanbwell/up-github-actions/blob/main/.github/scripts/pr_analyzer.py) into